### PR TITLE
Install Emacs 24.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.log
 *.gz
 *.bz2
+*.xz
 *.tgz
 *.tbz2
+*.txz
 *.zip

--- a/emacs/build.sh
+++ b/emacs/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/../common.sh
+
+VER="24.5"
+PREFIX="$ENGOPT/64/emacs-$VER"
+
+if [[ ! $0 == "-bash" ]]
+then	
+	configure_make_install emacs "http://ftpmirror.gnu.org/emacs/emacs-$VER.tar.xz"
+fi


### PR DESCRIPTION
Documents the new installation of Emacs 24 for request INC12018928 (needed on CentOS 6 nodes).
